### PR TITLE
SB-46: Block Creation Via Upload

### DIFF
--- a/frontend/src/renderer/App.jsx
+++ b/frontend/src/renderer/App.jsx
@@ -13,24 +13,34 @@ import { AduioBlock } from './Blocks/draggableBlocks';
 const Container = () => {
   return (
     <React.Fragment>
-      <div style={{width: "100%"}}>
-        <h1 style={{textAlign: "center", marginBottom: "0px"}}>Sound Blocks</h1> 
-        <br/> 
-        <h2 style={{textAlign: "center", marginTop: "0px"}}>Music Editing Software</h2>
+      <div style={{ width: '100%' }}>
+        <h1 style={{ textAlign: 'center', marginBottom: '0px' }}>
+          Sound Blocks
+        </h1>
+        <br />
+        <h2 style={{ textAlign: 'center', marginTop: '0px' }}>
+          Music Editing Software
+        </h2>
       </div>
-      <div style={{display: "flex", paddingTop: "25px", justifyContent: "center"}}>
+      <div
+        style={{
+          display: 'flex',
+          paddingTop: '25px',
+          justifyContent: 'center',
+        }}
+      >
         <BlockMenu />
-        <WorkSpace/>
-        <SoundLibrary/>
+        <WorkSpace />
+        <SoundLibrary />
       </div>
     </React.Fragment>
-  )
-}
+  );
+};
 
 const WorkSpace = () => {
   return (
-    <div style={{width: "50%", background: "grey"}}>
-      <h1 >WorkSpace</h1>
+    <div style={{ width: '50%', background: 'grey' }}>
+      <h1>WorkSpace</h1>
       <PlayButton />
       <Canvas />
     </div>
@@ -39,42 +49,40 @@ const WorkSpace = () => {
 
 const BlockMenu = () => {
   return (
-    <div style={{width: "25%", background: "white"}}>
+    <div style={{ width: '25%', background: 'white' }}>
       <h1>Block Menu</h1>
     </div>
-  )
-}
+  );
+};
 
 const SoundLibrary = () => {
-  const [activeFiles, setActiveFiles] = useState([])
+  const [activeFiles, setActiveFiles] = useState([]);
 
   const createBlock = (file) => {
-    console.log(file[0].name)
-    setActiveFiles([...activeFiles, file])
-  }
+    console.log(file[0].name);
+    setActiveFiles([...activeFiles, file]);
+  };
 
   return (
     <React.Fragment>
-      <div style={{width: "25%", background: "white"}}>
+      <div style={{ width: '25%', background: 'white' }}>
         <h1>Sound Library</h1>
-        <UploadFile createBlock={createBlock}/>
+        <UploadFile createBlock={createBlock} />
         {activeFiles.map((file) => (
-        <Draggable handle={true}>
-          <AduioBlock title = {file[0].name} duration = {"10"} />
-        </Draggable>
-      ))}
+          <Draggable handle={true}>
+            <AduioBlock title={file[0].name} duration={'10'} />
+          </Draggable>
+        ))}
       </div>
     </React.Fragment>
-  )
-
-}
-
+  );
+};
 
 export default function App() {
   return (
     <Router>
       <Routes>
-        <Route path="/" element={<Container/>} />
+        <Route path="/" element={<Container />} />
       </Routes>
     </Router>
   );

--- a/frontend/src/renderer/App.jsx
+++ b/frontend/src/renderer/App.jsx
@@ -5,6 +5,10 @@ import UploadFile from './Menu/UploadFile';
 import PlayButton from './Menu/PlayButton';
 import Canvas from './Canvas/Canvas';
 
+import { renderers } from './Blocks/fields';
+import { Draggable } from './Components/draggable';
+import { useState } from 'react';
+import { AduioBlock } from './Blocks/draggableBlocks';
 
 const Container = () => {
   return (
@@ -27,7 +31,6 @@ const WorkSpace = () => {
   return (
     <div style={{width: "50%", background: "grey"}}>
       <h1 >WorkSpace</h1>
-      <UploadFile />
       <PlayButton />
       <Canvas />
     </div>
@@ -43,14 +46,28 @@ const BlockMenu = () => {
 }
 
 const SoundLibrary = () => {
+  const [activeFiles, setActiveFiles] = useState([])
+
+  const createBlock = (file) => {
+    console.log(file[0].name)
+    setActiveFiles([...activeFiles, file])
+  }
+
   return (
-    <div style={{width: "25%", background: "white"}}>
-      <h1>Sound Library</h1>
-    </div>
+    <React.Fragment>
+      <div style={{width: "25%", background: "white"}}>
+        <h1>Sound Library</h1>
+        <UploadFile createBlock={createBlock}/>
+        {activeFiles.map((file) => (
+        <Draggable handle={true}>
+          <AduioBlock title = {file[0].name} duration = {"10"} />
+        </Draggable>
+      ))}
+      </div>
+    </React.Fragment>
   )
+
 }
-
-
 
 
 export default function App() {

--- a/frontend/src/renderer/Blocks/draggableBlocks.jsx
+++ b/frontend/src/renderer/Blocks/draggableBlocks.jsx
@@ -1,6 +1,6 @@
 import { renderers } from './fields';
 import { Draggable } from '../Components/draggable';
-
+import Slider from '../Components/Slider';
 export function PlayBlock() {
   const Component = renderers['play'];
   return (
@@ -17,4 +17,24 @@ export function SampleBlock() {
       <Component />
     </Draggable>
   );
+}
+
+export function AduioBlock(Props) {
+  return (
+      <div style={{ border: '1px solid black', borderRadius: "5px"}}>
+        <h4 style={{marginTop: "5px", marginBottom: "0px"}}>{Props.title}</h4>
+        <br/> 
+        <h5 style={{marginTop: "5px", marginBottom: "0px"}}> Duration: {Props.duration}</h5>
+        <div style={{display: 'flex', justifyContent: 'space-around'}}>
+          <div>
+            Attack
+          <Slider />
+          </div>
+          <div>
+            Stretch
+          <Slider />
+          </div>
+        </div>
+      </div>
+  )
 }

--- a/frontend/src/renderer/Blocks/draggableBlocks.jsx
+++ b/frontend/src/renderer/Blocks/draggableBlocks.jsx
@@ -21,20 +21,23 @@ export function SampleBlock() {
 
 export function AduioBlock(Props) {
   return (
-      <div style={{ border: '1px solid black', borderRadius: "5px"}}>
-        <h4 style={{marginTop: "5px", marginBottom: "0px"}}>{Props.title}</h4>
-        <br/> 
-        <h5 style={{marginTop: "5px", marginBottom: "0px"}}> Duration: {Props.duration}</h5>
-        <div style={{display: 'flex', justifyContent: 'space-around'}}>
-          <div>
-            Attack
+    <div style={{ border: '1px solid black', borderRadius: '5px' }}>
+      <h4 style={{ marginTop: '5px', marginBottom: '0px' }}>{Props.title}</h4>
+      <br />
+      <h5 style={{ marginTop: '5px', marginBottom: '0px' }}>
+        {' '}
+        Duration: {Props.duration}
+      </h5>
+      <div style={{ display: 'flex', justifyContent: 'space-around' }}>
+        <div>
+          Attack
           <Slider />
-          </div>
-          <div>
-            Stretch
+        </div>
+        <div>
+          Stretch
           <Slider />
-          </div>
         </div>
       </div>
-  )
+    </div>
+  );
 }

--- a/frontend/src/renderer/Canvas/Canvas.jsx
+++ b/frontend/src/renderer/Canvas/Canvas.jsx
@@ -8,9 +8,6 @@ export default function Canvas() {
     <DndContext>
       <PlayBlock />
       <PlayBlock />
-      <SampleBlock />
-      <SampleBlock />
-      <SampleBlock />
     </DndContext>
   );
 }

--- a/frontend/src/renderer/Menu/UploadFile.jsx
+++ b/frontend/src/renderer/Menu/UploadFile.jsx
@@ -37,9 +37,7 @@ function Dropzone(Props) {
         <div className="dropzone-div" {...getRootProps()}>
           <input className="dropzone-input" {...getInputProps()} />
           <p> Drag or drop .wav files here</p>
-          <aside>{thumbs}</aside>
         </div>
-        <button onClick={onUpload}>Upload</button>
       </div>
     </section>
   );

--- a/frontend/src/renderer/Menu/UploadFile.jsx
+++ b/frontend/src/renderer/Menu/UploadFile.jsx
@@ -9,14 +9,15 @@ import '../styles/UploadFile.css';
 import '../styles/Button.css';
 
 function Dropzone(Props) {
-  const { setOpen } = Props;
+  const { setOpen, createBlock } = Props;
+  
   const [files, setFiles] = useState([]);
 
   // This call back will be used to create a sample block once .wav files is droped
   const onDrop = useCallback((acceptedFiles) => {
     // const reader = new FileReader();
     // console.log(acceptedFiles[0], acceptedFiles[0].name, acceptedFiles[0].path, acceptedFiles[0].type);
-
+    console.log(acceptedFiles)
     setFiles(
       acceptedFiles.map((file) =>
         Object.assign(file, {
@@ -24,9 +25,10 @@ function Dropzone(Props) {
         })
       )
     );
+    console.log(Props);
+    createBlock(acceptedFiles)
+    //this.Props.createBlock(acceptedFiles);
   }, []);
-
-  console.log(files);
 
   // restrict to one .wav upload
   const constraints = {
@@ -36,6 +38,10 @@ function Dropzone(Props) {
     multiple: false,
   };
 
+
+  const onUpload = () => {
+   
+  }
   // clean up
   useEffect(
     () => () => {
@@ -63,23 +69,25 @@ function Dropzone(Props) {
           <p> Drag or drop .wav files here</p>
           <aside>{thumbs}</aside>
         </div>
+        <button onClick={onUpload}>Upload</button>
       </div>
     </section>
   );
 }
 
-function Popup() {
+function Popup(Props) {
+  //console.log(Props)  
   const [isOpen, setOpen] = useState(false);
   return (
     <>
       <button onClick={() => setOpen(true)}>
         <img width="20" alt="icon" src={upload} />
       </button>
-      {isOpen && <Dropzone setOpen={setOpen} />}
+      {isOpen && <Dropzone setOpen={setOpen} createBlock={Props.createBlock} />}
     </>
   );
 }
 
-export default function UploadFile() {
-  return <Popup />;
+export default function UploadFile(Props) {
+  return <Popup createBlock = {Props.createBlock}/>;
 }

--- a/frontend/src/renderer/Menu/UploadFile.jsx
+++ b/frontend/src/renderer/Menu/UploadFile.jsx
@@ -10,14 +10,14 @@ import '../styles/Button.css';
 
 function Dropzone(Props) {
   const { setOpen, createBlock } = Props;
-  
+
   const [files, setFiles] = useState([]);
 
   // This call back will be used to create a sample block once .wav files is droped
   const onDrop = useCallback((acceptedFiles) => {
     // const reader = new FileReader();
     // console.log(acceptedFiles[0], acceptedFiles[0].name, acceptedFiles[0].path, acceptedFiles[0].type);
-    console.log(acceptedFiles)
+    console.log(acceptedFiles);
     setFiles(
       acceptedFiles.map((file) =>
         Object.assign(file, {
@@ -26,7 +26,7 @@ function Dropzone(Props) {
       )
     );
     console.log(Props);
-    createBlock(acceptedFiles)
+    createBlock(acceptedFiles);
     //this.Props.createBlock(acceptedFiles);
   }, []);
 
@@ -38,10 +38,7 @@ function Dropzone(Props) {
     multiple: false,
   };
 
-
-  const onUpload = () => {
-   
-  }
+  const onUpload = () => {};
   // clean up
   useEffect(
     () => () => {
@@ -76,7 +73,7 @@ function Dropzone(Props) {
 }
 
 function Popup(Props) {
-  //console.log(Props)  
+  //console.log(Props)
   const [isOpen, setOpen] = useState(false);
   return (
     <>
@@ -89,5 +86,5 @@ function Popup(Props) {
 }
 
 export default function UploadFile(Props) {
-  return <Popup createBlock = {Props.createBlock}/>;
+  return <Popup createBlock={Props.createBlock} />;
 }

--- a/frontend/src/renderer/Menu/UploadFile.jsx
+++ b/frontend/src/renderer/Menu/UploadFile.jsx
@@ -10,26 +10,6 @@ import '../styles/Button.css';
 
 function Dropzone(Props) {
   const { setOpen, createBlock } = Props;
-
-  const [files, setFiles] = useState([]);
-
-  // This call back will be used to create a sample block once .wav files is droped
-  const onDrop = useCallback((acceptedFiles) => {
-    // const reader = new FileReader();
-    // console.log(acceptedFiles[0], acceptedFiles[0].name, acceptedFiles[0].path, acceptedFiles[0].type);
-    console.log(acceptedFiles);
-    setFiles(
-      acceptedFiles.map((file) =>
-        Object.assign(file, {
-          preview: URL.createObjectURL(file),
-        })
-      )
-    );
-    console.log(Props);
-    createBlock(acceptedFiles);
-    //this.Props.createBlock(acceptedFiles);
-  }, []);
-
   // restrict to one .wav upload
   const constraints = {
     accept: {
@@ -37,24 +17,17 @@ function Dropzone(Props) {
     },
     multiple: false,
   };
-
-  const onUpload = () => {};
-  // clean up
-  useEffect(
-    () => () => {
-      files.forEach((file) => URL.revokeObjectURL(file.preview));
-    },
-    [files]
-  );
-
-  const thumbs = files.map((file) => (
-    <div key={file.name}>
-      <audio controls src={file.preview} alt={file.name} />
-    </div>
-  ));
+  // This call back will be used to create a sample block once .wav files is droped
+  const onDrop = useCallback((acceptedFiles) => {
+    // const reader = new FileReader();
+    // console.log(acceptedFiles[0], acceptedFiles[0].name, acceptedFiles[0].path, acceptedFiles[0].type);
+    // console.log(Props);
+    createBlock(acceptedFiles);
+    //this.Props.createBlock(acceptedFiles);
+    setOpen(false);
+  }, []);
 
   const { getRootProps, getInputProps } = useDropzone({ onDrop, constraints });
-
   return (
     <section className="container">
       <div className="dropzone-container">


### PR DESCRIPTION
This PR includes...
 - removed samples from workspace
 - moved upload button from workspace to audio library
 - uploading a .wav file now create a draggable block in the audio library 
 - this block can be moved to the workspace
 - multiple blocks can be uploaded without overlapping

Video Demo:

https://user-images.githubusercontent.com/57294243/199775581-1ccac202-7640-4846-b1a1-f03ccc997f6d.mp4


